### PR TITLE
Clone test

### DIFF
--- a/pages/2home.jsx
+++ b/pages/2home.jsx
@@ -63,9 +63,6 @@ export default function HomeScreen(props) {
             <CPButton text="Delete" />
            </div>
           ),
-          // renderCell: (params) => (
-          //   <CPButton text="Export" onClick={() => handleNavigation(params.id)}/>
-          // )
         }
       ]);
 
@@ -73,7 +70,6 @@ export default function HomeScreen(props) {
   
     return(
       <div >
-        {/* <CreateNewModalFlow modalData={props.data} type={flowType.ENGAGEMENT} modalOpen={createNewFlow} onClose={() => {setCreateNewFlow(false); refreshData();}} /> */}
         <EngagementModalForm  modalFormType={modalFormType.NEW} 
                               isOpen={createNewFlow} 
                               onBack={() => setCreateNewFlow(false)} 

--- a/pages/2home.jsx
+++ b/pages/2home.jsx
@@ -4,8 +4,8 @@ import PlainScreen from "../components/baseScreen/PlainScreen";
 import { useRouter } from 'next/router'
 import { PlainTable } from "../components/tables/Table";
 import CPButton from '../components/button/CPButton';
-import CreateNewModalFlow from './createNewModalFlow';
-import { flowType } from '../util/modalUtils';
+import EngagementModalForm from './ModalForms/EngagementModalForm';
+import { modalFormType } from '../util/modalUtils';
 import { engagementColumns } from '../util/tableColumns';
 import styling from '../styles/tableStyling';
 import { useNavContext } from '../context/AppWrapper';
@@ -73,7 +73,12 @@ export default function HomeScreen(props) {
   
     return(
       <div >
-        <CreateNewModalFlow modalData={props.data} type={flowType.ENGAGEMENT} modalOpen={createNewFlow} onClose={() => {setCreateNewFlow(false); refreshData();}} />
+        {/* <CreateNewModalFlow modalData={props.data} type={flowType.ENGAGEMENT} modalOpen={createNewFlow} onClose={() => {setCreateNewFlow(false); refreshData();}} /> */}
+        <EngagementModalForm  modalFormType={modalFormType.NEW} 
+                              isOpen={createNewFlow} 
+                              onBack={() => setCreateNewFlow(false)} 
+                              onClose={()=> {setCreateNewFlow(false); refreshData();}}/>
+     
         <PlainScreen>
         <NavDir pages={directory} />
         <h1>Home</h1>

--- a/pages/6TestDetails.jsx
+++ b/pages/6TestDetails.jsx
@@ -91,7 +91,7 @@ export default function TestDetails(props) {
         return (
             <div style={{display: "flex", flexDirection: "column"}}>
                 <p>Name: {props.testData.name}</p>
-                <p>Most Recent Result Status: {props.testData.resultStatus?? "unknown"}</p>
+                <p>Most Recent Result Status: {props.testData.resultStatus?? "Unknown"}</p>
             </div>
         )
         // TODO: add result status in test schema so it can display the result status of the latest result

--- a/pages/ModalForms/TestModalForm.jsx
+++ b/pages/ModalForms/TestModalForm.jsx
@@ -10,12 +10,21 @@ import {modalFormType} from '../../util/modalUtils';
 
 export default function TestModalForm(props) {
   const router = useRouter();
-  const initialData = {
+
+  const initialData = (props.isClone)? 
+  {
+    _id: new ObjectID(),
+    name: (props.cloneData?.name??"") + " (copy)",
+    description: props.cloneData?.description??"",
+    resultStatus: props.data?.resultStatus??"Unknown"
+  }:{
+    // data is passed only from the edit 
     _id: props.data?._id??new ObjectID(),
     name: props.data?.name??"",
     description: props.data?.description??"",
-    resultStatus: props.data?.resultStatus??"unknown"
+    resultStatus: props.data?.resultStatus??"Unknown"
   }
+
   const [data, setData] = useState(initialData);
 
   function handleChange(evt) {
@@ -39,7 +48,7 @@ export default function TestModalForm(props) {
     let endPoint = '/api/editTest';
     let method = 'PUT';
     if (props.modalFormType==modalFormType.NEW){
-      endPoint = '/api/addNewTest';
+      endPoint = props.isClone?'/api/cloneTest':'/api/addNewTest';
       method = 'POST';
       newData["results"] = [];
     }
@@ -54,6 +63,7 @@ export default function TestModalForm(props) {
         },
         body: d,
       })
+      console.log("RES:", res)
     } catch (err){
       console.log("Error:",err)
     }

--- a/pages/createNewModalFlow.jsx
+++ b/pages/createNewModalFlow.jsx
@@ -24,18 +24,18 @@ export default function CreateNewModalFlow(props) {
 
     function renderColumns(type){
       switch (type){
-        case "Engagement":
-          return engagementColumns.concat([{ 
-            field: 'button', 
-            flex: 1,
-            minWidth: 100,
-            headerName: 'Actions',
-            headerClassName: 'header',
-            align: 'center',
-            renderCell: () => (
-              <CPButton text="clone" onClick={()=>setModalType(modalType.CLONE)}/>
-            )
-          }]); 
+        // case "Engagement":
+        //   return engagementColumns.concat([{ 
+        //     field: 'button', 
+        //     flex: 1,
+        //     minWidth: 100,
+        //     headerName: 'Actions',
+        //     headerClassName: 'header',
+        //     align: 'center',
+        //     renderCell: () => (
+        //       <CPButton text="clone" onClick={()=>setModalType(modalType.CLONE)}/>
+        //     )
+        //   }]); 
         case "Test Plan":
           return testPlanColumns.concat([
           { 
@@ -66,7 +66,6 @@ export default function CreateNewModalFlow(props) {
               renderCell: (data) => (
                 <CPButton text="clone" onClick={() => {setCloneData(data.row);
                                                         setModalType(modalType.SCRATCH);
-                                                        console.log(data)
                                                         }}/>
               )
             }
@@ -80,8 +79,10 @@ export default function CreateNewModalFlow(props) {
               headerName: 'Actions',
               headerClassName: 'header',
               align: 'center',
-              renderCell: () => (
-                <CPButton text="clone" onClick={() => {setModalType(modalType.CLONE)}}/>
+              renderCell: (data) => (
+                <CPButton text="clone" onClick={() => {setCloneData(data.row);
+                                                      setModalType(modalType.SCRATCH);
+                                                      console.log("cloneData", data)}}/>
               )
             }
             ]);
@@ -160,9 +161,14 @@ export default function CreateNewModalFlow(props) {
       case flowType.TEST:
         return <TestModalForm testCaseId={props.modalData.testCase._id} 
                               modalFormType={modalFormType.NEW} 
+                              cloneData={cloneData}
+                              isClone={isClone}
                               isOpen={scratchIsOpen} 
                               onBack={() => setModalType(modalType.START)}
-                              onClose={()=> {setScratchIsOpen(false); props.onClose();}} 
+                              onClose={()=> {setScratchIsOpen(false); 
+                                              setModalType(modalType.START);   
+                                              props.onClose();
+                                              setCloneData(null);}} 
                               />
       }
   }

--- a/pages/createNewModalFlow.jsx
+++ b/pages/createNewModalFlow.jsx
@@ -3,7 +3,7 @@ import Modal from 'react-modal';
 import CPButton from "../components/button/CPButton";
 import styles from '../styles/Modal.module.css';
 import {PlainTable} from '../components/tables/Table';
-import { engagementColumns, testPlanColumns, testCaseColumns, testColumns } from '../util/tableColumns';
+import { testPlanColumns, testCaseColumns, testColumns } from '../util/tableColumns';
 import { makeStyles } from '@mui/styles';
 import {flowType, modalType, modalFormType} from '../util/modalUtils';
 
@@ -24,18 +24,6 @@ export default function CreateNewModalFlow(props) {
 
     function renderColumns(type){
       switch (type){
-        // case "Engagement":
-        //   return engagementColumns.concat([{ 
-        //     field: 'button', 
-        //     flex: 1,
-        //     minWidth: 100,
-        //     headerName: 'Actions',
-        //     headerClassName: 'header',
-        //     align: 'center',
-        //     renderCell: () => (
-        //       <CPButton text="clone" onClick={()=>setModalType(modalType.CLONE)}/>
-        //     )
-        //   }]); 
         case "Test Plan":
           return testPlanColumns.concat([
           { 
@@ -105,7 +93,6 @@ export default function CreateNewModalFlow(props) {
       <Modal className={styles.Modal} isOpen={true}>
           <h2>Choose an Existing {props.type} to Clone</h2>
           <PlainTable 
-              // rows={props.modalData}
               rows={renderRows(props.type)}
               columns={renderColumns(props.type)}
               className={classes.root}/> 


### PR DESCRIPTION
- clone test api and front-end should be working
- the home page **Add New** button originally allows user to choose whether to clone or add engagement from scratch. Since we now decided that cloning an engagement is not allowed, the button directly goes to add an engagement from scratch modal 
   - I also commenting out all the Engagement related things in the createNewModalFlow that I think should be deleted if the reviewer approves

